### PR TITLE
Extra detection to prevent switching elytra while riding a Happy Ghast

### DIFF
--- a/common/src/main/java/cn/com/fakeneko/auto_switch_elytra/mixin/MixinClientPlayerEntity.java
+++ b/common/src/main/java/cn/com/fakeneko/auto_switch_elytra/mixin/MixinClientPlayerEntity.java
@@ -141,6 +141,10 @@ public class MixinClientPlayerEntity extends AbstractClientPlayer {
 
     // 判断是否可以起飞
     private boolean canStartFly(LocalPlayer player) {
-        return !player.onGround() && !player.isFallFlying() && !player.isInWater() && !player.hasEffect(MobEffects.LEVITATION);
+        return !(player.onGround()
+                || player.isFallFlying()
+                || player.isInWater()
+                || player.hasEffect(MobEffects.LEVITATION)
+                || player.isPassenger());
     }
 }


### PR DESCRIPTION
添加骑乘判定防止骑快乐恶魂时切换鞘翅
Added extra detection to prevent switching elytra while riding a Happy Ghast